### PR TITLE
Adding extra info

### DIFF
--- a/src/resetting-progress-in-a-deck.md
+++ b/src/resetting-progress-in-a-deck.md
@@ -8,7 +8,7 @@ Resetting cards within Anki
 --------------------------------
 
 1. Find the cards you want to reset in the browser.
-2. Select all the cards and choose Cards->Reschedule or Edit->Reschedule, then *Place at end of new card queue*. Click OK.
+2. Select all the cards and choose Cards->Forget.
 
 When you do this, Anki will turn the cards back into new cards. If you click Info in the browser you'll see any previous reviews you've done listed there, but that history will not influence how the cards are scheduled: they will be treated just like new cards.
 

--- a/src/shortcut-not-working.md
+++ b/src/shortcut-not-working.md
@@ -5,3 +5,5 @@ Some other program on your computer is likely capturing the shortcut. For exampl
 If you run into similar problems, please try temporarily closing/turning off other software running on your machine, until you discover the cause.
 
 If you use add-ons in Anki, please also try disabling them to rule them out as the cause of the problem.
+
+In some cases, using a non-english keyboard layout may cause the problem. 

--- a/src/shortcut-not-working.md
+++ b/src/shortcut-not-working.md
@@ -6,4 +6,4 @@ If you run into similar problems, please try temporarily closing/turning off oth
 
 If you use add-ons in Anki, please also try disabling them to rule them out as the cause of the problem.
 
-In some cases, using a non-english keyboard layout may cause the problem. 
+In some cases, using a non-English keyboard layout may cause the problem. 

--- a/src/what-spaced-repetition-algorithm.md
+++ b/src/what-spaced-repetition-algorithm.md
@@ -112,7 +112,8 @@ After you select an ease button, Anki also applies a small amount of
 random “fuzz” to prevent cards that were introduced at the same time and
 given the same ratings from sticking together and always coming up for
 review on the same day. This fuzz appear on the interval
-buttons from 2.1.45+, but if you are using a previous version and you’re 
+buttons from 2.1.45+, but not in previous versions, so if you are using 
+a previous version and you’re 
 noticing a slight discrepancy between what you
 select and the intervals your cards actually get, this is probably the
 cause.

--- a/src/what-spaced-repetition-algorithm.md
+++ b/src/what-spaced-repetition-algorithm.md
@@ -96,7 +96,7 @@ bonus* and the ease is increased by 15 percentage points.
 For Hard, Good, and Easy, the next interval is additionally multiplied
 by the *interval modifier*. If the card is being reviewed late,
 additional days will be added to the current interval, as described
-in a previous FAQ.
+in a [previous FAQ.](https://faqs.ankiweb.net/due-times-after-a-break.html)
 
 
 ## Limitations and Fuzz.

--- a/src/what-spaced-repetition-algorithm.md
+++ b/src/what-spaced-repetition-algorithm.md
@@ -44,7 +44,7 @@ You can also check out `sched.py` and `schedv2.py` in Anki’s source code for t
 scheduling code. Here is a summary (see the [deck options](https://docs.ankiweb.net/deck-options.html)
 section of the manual for the options that are mentioned in *italics*).
 
-## New and Relearning cards.
+## Learning/Relearning Cards
 If you press…​
 
 - Again  

--- a/src/what-spaced-repetition-algorithm.md
+++ b/src/what-spaced-repetition-algorithm.md
@@ -50,7 +50,7 @@ If you press…​
 - Again  
 Moves the card back to the first step setted in [*Learning/Relearning Steps.*](https://docs.ankiweb.net/deck-options.html?#learning-steps)
 
-- Hard 
+- Hard  
 Repeats the current step after the first step, and is the average of 
 Again and Good.
 
@@ -83,7 +83,7 @@ when the card exits relearning mode).
 
 - Hard  
 The card’s ease is decreased by 15 percentage points and the current
-interval is multiplied by 1.2.
+interval is multiplied by the value of *hard interval* (1.2 by default)
 
 - Good  
 The current interval is multiplied by the current ease. The ease is

--- a/src/what-spaced-repetition-algorithm.md
+++ b/src/what-spaced-repetition-algorithm.md
@@ -44,7 +44,32 @@ You can also check out `sched.py` and `schedv2.py` in Anki’s source code for t
 scheduling code. Here is a summary (see the [deck options](https://docs.ankiweb.net/deck-options.html)
 section of the manual for the options that are mentioned in *italics*).
 
-## Review cards
+## New cards.
+If you press…​
+
+- Again  
+Moves the card back to the first step setted in [*Learning Steps.*](https://docs.ankiweb.net/deck-options.html?#learning-steps)
+
+- Hard 
+Repeats the current step after the first step, and is the average of 
+Again and Good.
+
+- Good  
+Moves the card to the [*next step*](https://docs.ankiweb.net/deck-options.html?#learning-steps). 
+If the card was on the final step, the card is converted into a 
+review card (it 'graduates').
+
+- Easy 
+Immediately converts the card into a review card. 
+
+New cards have no ease, so no matter how many times you press
+'Again' or 'Hard', the future ease factor of the card won't be affected. 
+
+
+## Review cards.
+Once a card is graduated, it gets an ease factor. By default is 2.5, but you
+can set another value using the [Deck Options](https://docs.ankiweb.net/deck-options.html?#starting-ease). 
+
 If you press…​
 
 - Again  
@@ -71,6 +96,10 @@ by the *interval modifier*. If the card is being reviewed late,
 additional days will be added to the current interval, as described
 in a previous FAQ.
 
+## Relearning cards.
+
+
+## Limitations and Fuzz.
 There are a few limitations on the scheduling values that cards can
 take. Eases will never be decreased below 130%; SuperMemo’s research has
 shown that eases below 130% tend to result in cards becoming due more

--- a/src/what-spaced-repetition-algorithm.md
+++ b/src/what-spaced-repetition-algorithm.md
@@ -48,14 +48,14 @@ section of the manual for the options that are mentioned in *italics*).
 If you press…​
 
 - Again  
-Moves the card back to the first step setted in [*Learning/Relearning Steps.*](https://docs.ankiweb.net/deck-options.html?#learning-steps)
+Moves the card back to the first step setted in [Learning/Relearning Steps.](https://docs.ankiweb.net/deck-options.html?#learning-steps)
 
 - Hard  
 Repeats the current step after the first step, and is the average of 
 Again and Good.
 
 - Good  
-Moves the card to the [*next step*](https://docs.ankiweb.net/deck-options.html?#learning-steps). 
+Moves the card to the [next step](https://docs.ankiweb.net/deck-options.html?#learning-steps). 
 If the card was on the final step, the card is converted into a 
 review card (it 'graduates').
 

--- a/src/what-spaced-repetition-algorithm.md
+++ b/src/what-spaced-repetition-algorithm.md
@@ -68,7 +68,7 @@ The same can be said about relearning cards: pressing 'Again'
 or 'Hard' won't have any effect over the card's ease. 
 
 
-## Review cards.
+## Review Cards
 Once a card is graduated, it gets an ease factor. By default is 2.5, but you
 can set another value using the [Deck Options](https://docs.ankiweb.net/deck-options.html?#starting-ease). 
 

--- a/src/what-spaced-repetition-algorithm.md
+++ b/src/what-spaced-repetition-algorithm.md
@@ -99,7 +99,7 @@ additional days will be added to the current interval, as described
 in a [previous FAQ.](https://faqs.ankiweb.net/due-times-after-a-break.html)
 
 
-## Limitations and Fuzz.
+## Limitations and Fuzz
 There are a few limitations on the scheduling values that cards can
 take. Eases will never be decreased below 130%; SuperMemo’s research has
 shown that eases below 130% tend to result in cards becoming due more

--- a/src/what-spaced-repetition-algorithm.md
+++ b/src/what-spaced-repetition-algorithm.md
@@ -44,11 +44,11 @@ You can also check out `sched.py` and `schedv2.py` in Anki’s source code for t
 scheduling code. Here is a summary (see the [deck options](https://docs.ankiweb.net/deck-options.html)
 section of the manual for the options that are mentioned in *italics*).
 
-## New cards.
+## New and Relearning cards.
 If you press…​
 
 - Again  
-Moves the card back to the first step setted in [*Learning Steps.*](https://docs.ankiweb.net/deck-options.html?#learning-steps)
+Moves the card back to the first step setted in [*Learning/Relearning Steps.*](https://docs.ankiweb.net/deck-options.html?#learning-steps)
 
 - Hard 
 Repeats the current step after the first step, and is the average of 
@@ -64,6 +64,8 @@ Immediately converts the card into a review card.
 
 New cards have no ease, so no matter how many times you press
 'Again' or 'Hard', the future ease factor of the card won't be affected. 
+The same can be said about relearning cards: pressing 'Again' 
+or 'Hard' won't have any effect over the card's ease. 
 
 
 ## Review cards.
@@ -95,8 +97,6 @@ For Hard, Good, and Easy, the next interval is additionally multiplied
 by the *interval modifier*. If the card is being reviewed late,
 additional days will be added to the current interval, as described
 in a previous FAQ.
-
-## Relearning cards.
 
 
 ## Limitations and Fuzz.

--- a/src/what-spaced-repetition-algorithm.md
+++ b/src/what-spaced-repetition-algorithm.md
@@ -44,24 +44,25 @@ You can also check out `sched.py` and `schedv2.py` in Anki’s source code for t
 scheduling code. Here is a summary (see the [deck options](https://docs.ankiweb.net/deck-options.html)
 section of the manual for the options that are mentioned in *italics*).
 
+## Review cards
 If you press…​
 
-Again  
+- Again  
 The card is placed into relearning mode, the ease is decreased by 20
 percentage points (that is, 20 is subtracted from the *ease* value,
 which is in units of percentage points), and the current interval is
 multiplied by the value of *new interval* (this interval will be used
 when the card exits relearning mode).
 
-Hard  
+- Hard  
 The card’s ease is decreased by 15 percentage points and the current
 interval is multiplied by 1.2.
 
-Good  
+- Good  
 The current interval is multiplied by the current ease. The ease is
 unchanged.
 
-Easy  
+- Easy  
 The current interval is multiplied by the current ease times the *easy
 bonus* and the ease is increased by 15 percentage points.
 
@@ -81,8 +82,9 @@ previous interval.
 After you select an ease button, Anki also applies a small amount of
 random “fuzz” to prevent cards that were introduced at the same time and
 given the same ratings from sticking together and always coming up for
-review on the same day. This fuzz does not appear on the interval
-buttons, so if you’re noticing a slight discrepancy between what you
+review on the same day. This fuzz appear on the interval
+buttons from 2.1.45+, but if you are using a previous version and you’re 
+noticing a slight discrepancy between what you
 select and the intervals your cards actually get, this is probably the
 cause.
 


### PR DESCRIPTION
The algorith works differently with new / relearn cards than with review cards, just added the  new / relearn cards section to clarify how ease gets affected in both cases. 

Some redundancy here, yes, but I think it's important to have this information at the same place, otherwise it remains disperse over several chapters of the manual. 

As always, feel free to discard. 

Thanks!
