### PR TITLE
Updates line about AnkiDroid support for v3 scheduler

### DIFF
--- a/src/the-2021-scheduler.md
+++ b/src/the-2021-scheduler.md
@@ -173,8 +173,7 @@ if (states.good.normal?.review) {
 ```
 
 Because this is implemented in JavaScript, it is not limited to the computer
-version. AnkiMobile supports it as well, and AnkiWeb and AnkiDroid may support
-it in the future too. This will allow advanced users to make adjustments to the
+version. AnkiMobile and AnkiDroid both support it as well, and AnkiWeb may support it in the future too. This will allow advanced users to make adjustments to the
 standard scheduling behaviour, that apply on all platforms.
 
 The various scheduling states are described in SchedulingStates [here](https://github.com/ankitects/anki/blob/main/proto/anki/scheduler.proto).

--- a/src/the-2021-scheduler.md
+++ b/src/the-2021-scheduler.md
@@ -173,7 +173,8 @@ if (states.good.normal?.review) {
 ```
 
 Because this is implemented in JavaScript, it is not limited to the computer
-version. AnkiMobile and AnkiDroid both support it as well, and AnkiWeb may support it in the future too. This will allow advanced users to make adjustments to the
-standard scheduling behaviour, that apply on all platforms.
+version. AnkiMobile and AnkiDroid both support it as well, and AnkiWeb may
+support it in the future too. This will allow advanced users to make 
+adjustments to the standard scheduling behaviour, that apply on all platforms.
 
 The various scheduling states are described in SchedulingStates [here](https://github.com/ankitects/anki/blob/main/proto/anki/scheduler.proto).


### PR DESCRIPTION
Updates line about v3 support for AnkiDroid since it is now the standard there.

I want sure about AnkiWeb since I don't use it. I did a brief check to see if it had a v2/v3 option but I couldn't find any so I assumed that it's not a thing.

If it turns out that it's like AnkiDroid and that the only option under the hood is v3 I would be happy to change it again.