### PR TITLE
Update book.toml redirect

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -23,4 +23,4 @@ exclude = [ 'quora\.com', 'reddit.com', 'superuser.com', 'github.com/open-spaced
 
 [output.html.redirect]
 # redirect deleted pages to new pages to preserve legacy links
-"../note-types-with-strange-names.html" = "../removing-duplicate-note-types.html"
+"./src/note-types-with-strange-names.md" = "./src/removing-duplicate-note-types.md"


### PR DESCRIPTION
My attempt in #42 resulted in a 404 error at https://faqs.ankiweb.net/note-types-with-strange-names.html once published. 
`"../note-types-with-strange-names.html" = "../removing-duplicate-note-types.html"`
![image](https://github.com/user-attachments/assets/02f295c2-f5fa-4022-afcd-a396a5744539)

Trying again with different syntax for the redirect:
`"./src/note-types-with-strange-names.md" = "./src/removing-duplicate-note-types.md"`