### PR TITLE
Update book.toml redirect

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -23,4 +23,4 @@ exclude = [ 'quora\.com', 'reddit.com', 'superuser.com', 'github.com/open-spaced
 
 [output.html.redirect]
 # redirect deleted pages to new pages to preserve legacy links
-"./src/note-types-with-strange-names.md" = "./src/removing-duplicate-note-types.md"
+"note-types-with-strange-names.html" = "removing-duplicate-note-types.html"


### PR DESCRIPTION
My attempt in #42 resulted in a 404 error at https://faqs.ankiweb.net/note-types-with-strange-names.html once published. 
`"../note-types-with-strange-names.html" = "../removing-duplicate-note-types.html"`
Same for attempt in #44 .
`"./src/note-types-with-strange-names.md" = "./src/removing-duplicate-note-types.md"`

Trying again with simpler syntax for the redirect:
`"note-types-with-strange-names.html" = "removing-duplicate-note-types.html"`
